### PR TITLE
Add docker compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+    bodypix:
+        image: bodypix
+        build:
+            context: ./bodypix
+        read_only: true
+
+    fakecam:
+        image: fakecam
+        build:
+            context: ./fakecam
+        read_only: true
+        # volumes:
+        #   - /path/to/background.jpg:/data/background.jpg:ro
+        devices:
+            # input (webcam)
+            - /dev/video0:/dev/video0
+            # output (virtual webcam)
+            - /dev/video2:/dev/video2
+        depends_on:
+            - bodypix


### PR DESCRIPTION
I personally would prefer to drop all the shell scripts (build.sh, remove-*.sh, ...) and replace them with this single docker-compose.yml file.

Run and initial build containers: `docker-compose up`  (or `docker-compose up -d`)
Stop and remove containers: `docker-compose down`

The compose file can also be edited to map another background image or use different video devices without needing to rebuild the docker images.