### PR TITLE
Fix leftover argument error on main Python object. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ I also created ``/etc/modules-load.d/v4l2loopback`` with the following content:
 This automatically loads v4l2loopback module at boot, with the specified module
 options.
 
+If you get an error like
+```
+OSError: [Errno 22] Invalid argument
+```
+
+when opening the webcam from Python, please install v4l2loopback from the [github](https://github.com/umlaeute/v4l2loopback) repo, 
+as you could have an old version from your package manager.
+
 ## Installing with Docker
 Please refer to [DOCKER.md](DOCKER.md). The updated Docker related files were
 added by [liske](https://github.com/liske).

--- a/fakecam/fake.py
+++ b/fakecam/fake.py
@@ -169,7 +169,7 @@ def main():
         width=args.width,
         height=args.height,
         scale_factor=args.scale_factor,
-        process_foreground=args.no_foreground,
+        no_foreground=args.no_foreground,
         bodypix_url=args.bodypix_url,
         background_image=args.background_image,
         foreground_image=args.foreground_image,


### PR DESCRIPTION
Apologies, I forgot to change an argument name in the previous PR..

Added also a note about v4l2loopback in README.

Signed-off-by: Bigo <bigo@crisidev.org>