### PR TITLE
Fix ImportError: No module named 'aiohttp'

### DIFF
--- a/fakecam/Dockerfile
+++ b/fakecam/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
       && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir pyfakewebcam
+RUN pip3 install --no-cache-dir aiohttp
 
 WORKDIR /src
 


### PR DESCRIPTION
The fakecam Dockerfile is missing the installation of the "aiohttp" module. When running `docker-compose up`, the container will stop with the following error when trying to run `fake.py`:
```
ImportError: No module named 'aiohttp'
```

An even better long-term solution would be to copy the `requirements.txt` file to the container and `pip install -r requirements.txt` for example:
```
COPY requirements.txt /src/requirements.txt
RUN pip3 install --no-cache-dir /src/requirements.txt
```
But I haven't done so because numpy and opencv are installed using `apt-get` and `pip` could override those.