### PR TITLE
bodypix: Turn hardcoded defaults into options

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,19 @@ If you are not running fakecam.py under Docker, it supports the following option
 ### bodypix/app.js
 If under/over-segmentation occurs, you can tweak ``segmentationThreshold``. To
 make the network run faster, you can change ``internalResolution``, however this
-will reduce segmentation accuracy.
+will reduce segmentation accuracy. Both and other variables can be changed by
+exposing them via environment variables before running bodypix. See the bodypix
+[manual](https://github.com/tensorflow/tfjs-models/blob/master/body-pix/README.md)
+for detailed information about these.
+
+```
+BPHFLIP     - Horizontal flip [ true, false ]
+BPIRES      - Internal Resolution [ 0.0, 1.0 ]
+BPMULTI     - Multiplier [ 0.0, 1.0 ]
+BPOUTSTRIDE - Output Stride [ 8, 16, 32 ]
+BPQBYTES    - Quantization bytes [ 1, 2, 4 ]
+BPSEGTHRES  - Segmentation Threshold [ 0.0, 1.0 ]
+```
 
 #### Compilation of Tensorflow C library
 Tensorflow.js uses Tensorflow C library. The default version shipped with

--- a/bodypix/app.js
+++ b/bodypix/app.js
@@ -1,5 +1,11 @@
 
-const PORT = process.env.PORT || 9000;
+const HFLIP = process.env.BPHFLIP || false;
+const IRES = parseFloat(process.env.BPIRES) || 0.5;
+const MULTI = parseFloat(process.env.BPMULTI) || 0.75;
+const OUTSTRIDE = parseInt(process.env.BPOUTSTRIDE) || 16;
+const PORT = process.env.BPPORT || 9000;
+const QBYTES = parseInt(process.env.BPQBYTES) || 2;
+const SEGTHRES = parseFloat(process.env.BPSEGTHRES) || 0.75;t PORT = process.env.PORT || 9000;
 const tf = tensorflow();
 
 const bodyPix = require('@tensorflow-models/body-pix');
@@ -7,9 +13,9 @@ const http = require('http');
 (async () => {
     const net = await bodyPix.load({
         architecture: 'MobileNetV1',
-        outputStride: 16,
-        multiplier: 0.75,
-        quantBytes: 2,
+        outputStride: OUTSTRIDE,
+        multiplier: MULTI,
+        quantBytes: QBYTES,
     });
     const server = http.createServer();
     server.on('request', async (req, res) => {
@@ -20,9 +26,9 @@ const http = require('http');
         req.on('end', async () => {
             const image = tf.node.decodeImage(Buffer.concat(chunks));
             segmentation = await net.segmentPerson(image, {
-                flipHorizontal: false,
-                internalResolution: 'medium',
-                segmentationThreshold: 0.75,
+                flipHorizontal: HFLIP,
+                internalResolution: IRES,
+                segmentationThreshold: SEGTHRES,
             });
             res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
             res.write(Buffer.from(segmentation.data));


### PR DESCRIPTION
By treating the configurable parameters as environment variables, we
can tune and tweak bodypix more during startup.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>