### PR TITLE
Use tini for quicker exit.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,15 @@
-version: '3'
+version: '3.7'
 services:
     bodypix:
         image: bodypix
+        init: true
         build:
             context: ./bodypix
         read_only: true
 
     fakecam:
         image: fakecam
+        init: true
         build:
             context: ./fakecam
         read_only: true


### PR DESCRIPTION
This gives better signal handling.

For example:

- Run `docker-compose up`
- When you want to stop it, press `CTRL-c` in the same console.
- It now exits cleanly quickly, instead of very slowly and then abruptly.

Similar example:

- Run `docker-compose up -d`
- When you want to stop it, run `docker-compose down` in another console.
- It now exits cleanly quickly, instead of very slowly and then abruptly.
