### PR TITLE
[FIX] Command to add user to group is useradd

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -81,7 +81,7 @@ docker run -d \
 
 Start the camera, note that we need to pass through video devices,
 and we want our user ID and group to have permission to them
-you may need to `sudo groupadd $USER video`:
+you may need to `sudo useradd $USER video`:
 
 ```bash
 docker run -d \


### PR DESCRIPTION
The command written in the documentation to add `$USER` to the `video` group was wrong. `groupadd` creates a group, while `useradd` (among others) adds a user to a group.