### PR TITLE
Use distinct Python version

### DIFF
--- a/fakecam/Dockerfile
+++ b/fakecam/Dockerfile
@@ -1,9 +1,7 @@
-FROM debian:bullseye
+FROM python:3.8
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      python3 \
-      python3-pip \
       python3-numpy \
       python3-opencv \
       python3-requests \


### PR DESCRIPTION
Installing `numpy` fails, when we build the Dockerfile of `fakecam`. By switching from debian to the offical Python image, we can select a Python version. With version 3.8 the build runs successfully.
