### PR TITLE
Update opencv-python and numpy

### DIFF
--- a/fakecam/requirements.txt
+++ b/fakecam/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.18.2
-opencv-python==4.2.0.32
+numpy==1.19.3
+opencv-python==4.4.0.46
 requests==2.23.0
 requests-unixsocket==0.2.0
 pyfakewebcam==0.1.0


### PR DESCRIPTION
opencv-python 4.2.0.32 no longer seems to be available for download from pip. 4.4.0.46 is available and seems to work with a simple background removal test with OBS and Manjaro Linux. 4.4.0.46 requires numpy 1.19.3.

Original error:

`Collecting numpy==1.18.2
Using cached numpy-1.18.2.zip (5.4 MB)
Installing build dependencies ... done
Getting requirements to build wheel ... done
  Preparing wheel metadata ... done
ERROR: Could not find a version that satisfies the requirement opencv-python==4.2.0.34 (from -r fakecam/requirements.txt (line 2)) (from versions: 3.4.10.37, 3.4.11.39, 3.4.11.41, 3.4.11.43, 3.4.11.45, 3.4.13.47, 4.3.0.38, 4.4.0.40, 4.4.0.42, 4.4.0.44, 4.4.0.46, 4.5.1.48)                          
ERROR: No matching distribution found for opencv-python==4.2.0.34 (from -r fakecam/requirements.txt (line 2))`
