### PR TITLE
:bug: Make hologram appear again

### DIFF
--- a/fake.py
+++ b/fake.py
@@ -266,7 +266,7 @@ then scale & crop the image so that its pixels retain their aspect ratio."""
         mask =  self.classifier.process(frame).segmentation_mask
 
         if self.hologram:
-            foreground_frame = self.hologram_effect(foreground_frame)
+            frame = self.hologram_effect(frame)
 
         # Get background image
         if self.no_background is False:


### PR DESCRIPTION
`foreground_frame` is no longer defined since the code cleanup, which throws a runtime exception. Replaced with an existing variable, which makes the code work.