### PR TITLE
Ondemand video processing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.19.3
 opencv-python>=4.4.0.46
 pyfakewebcam>=0.1.0
 mediapipe>=0.8.5
+inotify_simple>=1.2


### PR DESCRIPTION
Consumer detection using inotify enabling ondemand processing as described in  [#119](https://github.com/fangfufu/Linux-Fake-Background-Webcam/issues/119). When started with the command line option --ondemand Linux-Fake-Background tracks the presence of consumers accessing the virtual video device and disables/enables processing based on this. Thus there is no relevant system load when the video stream is not being needed, giving the option of running Linux-Fake-Background in background.