### PR TITLE
Use iterative-gaussian blur for background

### DIFF
--- a/fake.py
+++ b/fake.py
@@ -285,7 +285,7 @@ then scale & crop the image so that its pixels retain their aspect ratio."""
 
         if self.postprocess:
             mask = cv2.dilate(mask, np.ones((5,5), np.uint8) , iterations=1)
-            mask = cv2.blur(mask.astype(float), (10,10))
+            mask = cv2.medianBlur(mask, 5)
 
         if self.MRAR < 1:
             if self.old_mask is None:
@@ -297,10 +297,26 @@ then scale & crop the image so that its pixels retain their aspect ratio."""
         if self.no_background is False:
             background_frame = next(self.images["background"])
         else:
-            background_frame = cv2.blur(frame,
-                                        (self.background_blur,
-                                         self.background_blur),
-                                        cv2.BORDER_DEFAULT)
+
+            # copy frame by downscaling 
+            frameWidth = frame.shape[1]
+            frameHeight = frame.shape[0]
+
+            width = int(frameWidth * .25)
+            height = int(frameHeight * .25)
+            background_frame = cv2.resize(frame, (width, height), interpolation = cv2.INTER_LINEAR)
+
+            # apply background blur to resized frame
+            for i in range(1, self.background_blur, 2):
+                background_frame = cv2.GaussianBlur(background_frame,
+                    (i,i),
+                    cv2.BORDER_DEFAULT)
+                background_frame = cv2.GaussianBlur(background_frame,
+                    (i,i),
+                    cv2.BORDER_DEFAULT)
+
+            # re-expand background frame.
+            background_frame = cv2.resize(background_frame, (frameWidth, frameHeight), interpolation = cv2.INTER_AREA)
 
         frame.flags.writeable = True
 

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-pip3 install --user -r requirements.txt
+python3.7 -m pip install --user -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.19.3
 opencv-python>=4.4.0.46
 pyfakewebcam>=0.1.0
-mediapipe==0.8.5
+mediapipe==0.8.6.2
 inotify_simple>=1.2


### PR DESCRIPTION
I liked this project quite a lot, but wanted to heavily blur my background. The box blur that's done in master branch leads to "banding", which is pretty common with heavy box blurs (since it's unweighted). It's also a bit slow at higher kernel sizes.

This change downsamples first, then runs an iterative gauss blur (using the number of iterations from `background_blur` that users pass in), then upscales with a linear area filter. It went from ~20fps with master to >30fps (my camera doesnt go faster than that) with this branch. 
Here's a before/after of what it looks like for me;

![beforeafter](https://user-images.githubusercontent.com/5728164/128255881-763338fa-051d-4da4-90f3-e3fe2dec82c4.png)

It's most noticeable on the black lamp stem, which appears to be almost two different stems with master branch, and the edge of the chair, which similarly gets "pulled out".

Finally to get it to build i had to jump through hoops getting the right python (only 3.7+ works, which is not what you get from `python3` in mint/ubuntu), so that's why the install and requirements are "updated" to use newer versions - it took some work to get to that point. I wouldn't protest if that part should get cut, i'm sure other people have other setups, but included it anyway.