### PR TITLE
Apply colormaps: use cmapy to colorize cam output (like the hologram effect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ on-demand processing behaviour by specifying the ``--no-ondemand`` flag.
 Note that animated background is supported. You can use any video file that can
 be read by OpenCV.
 
+With the `--cmapy` option, any of the colormaps that are 
+[available](https://gitlab.com/cvejarano-oss/cmapy/blob/master/docs/colorize_all_examples.md)
+in the CMaPy package can be applied.
+
+`--cmapy-bg` applies the same colormap to the background.
+
+`--gray` is a shorthand for `--cmapy gist_yarg_r` - i.e. applies a grayscale effect 
+
 ### fake.py
 
 ``fakecam.py`` supports the following options:
@@ -202,6 +210,7 @@ usage: fake.py [-h] [-W WIDTH] [-H HEIGHT] [-F FPS] [-C CODEC]
                [--no-ondemand]
                [--background-mask-update-speed BACKGROUND_MASK_UPDATE_SPEED]
                [--use-sigmoid] [--threshold THRESHOLD] [--no-postprocess]
+               [--cmapy-bg] [--cmapy PROFILE] [--gray]
 
 Faking your webcam background under GNU/Linux. Please refer to:
 https://github.com/fangfufu/Linux-Fake-Background-Webcam
@@ -255,6 +264,10 @@ optional arguments:
                         as foreground (default: 75)
   --no-postprocess      Disable postprocessing (masking dilation and blurring)
                         (default: True)
+  -M CMAPY, --cmapy PRESET    Apply a colormap preset
+  --cmapy-bg            Apply colormap to background
+  --gray                Apply a grayscale effect, identical to --cmapy gist_yarg_r 
+                        
 ```
 ## License
 The source code of this repository are released under GPLv3.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ opencv-python>=4.4.0.46
 pyfakewebcam>=0.1.0
 mediapipe>=0.8.6.2
 inotify_simple>=1.2
+cmapy>=0.6.6


### PR DESCRIPTION
allows applying colormaps to the body outline (zombies etc)
or applying to the background as well (blending the foreground into b&w backgrounds)

Adds command line options:

--cmapy COLORMAP : apply a colormap to foreground
--cmapy-bg : also apply the same colormap to background
--gray : shorthand to apply the gist_yarg_r grayscale colormap

(See e.g. https://gitlab.com/cvejarano-oss/cmapy/blob/master/docs/colorize_all_examples.md for the preset names and preview images.)

Resubmitting: fixed the bug from #128 which caused a colormap to always apply and was reverted in #130 