### PR TITLE
Add cmapy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ opencv-python>=4.4.0.46
 pyfakewebcam>=0.1.0
 mediapipe==0.8.5
 inotify_simple>=1.2
+cmapy>=0.6.6


### PR DESCRIPTION
As-is, a fresh environment with requirements from `requirements.txt` produces:

```
$ python fake.py -v  /dev/video6  --no-background --no-foreground
Traceback (most recent call last):
  File "fake.py", line 17, in <module>
    from cmapy import cmap
ModuleNotFoundError: No module named 'cmapy'
```