### PR TITLE
Add benchmark script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 resources
 *.kate-swp
+benchmark.*.txt

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+width=1920
+height=1080
+fps=60
+timeout=180
+video_url="https://google.github.io/mediapipe/images/selfie_segmentation_web.mp4"
+
+for ffmpeg in ffmpeg avconv ""; do
+    test -n "$ffmpeg" || {
+        echo "This script needs ffmpeg or avconv."
+        exit 1
+    }
+    command -v "$ffmpeg" >/dev/null && break || :
+done
+
+# get sudo password and keep it active
+sudo -v
+( while sleep 1; do sudo -v; done; ) &
+pids="$!"
+
+# create file for test video
+video="$(mktemp)"
+
+# registister cleanup function
+cleanup() {
+    rm -f -- "$video"
+    kill $pids; wait
+    sudo -- $SHELL -c 'modprobe -r v4l2loopback; modprobe v4l2loopback'
+}
+trap cleanup EXIT
+
+# create the necessary v4l2loopback devices
+sudo -- $SHELL -s <<EOF
+modprobe -r v4l2loopback
+modprobe v4l2loopback devices=2 exclusive_caps=1,1 video_nr=99,100
+EOF
+
+# download video and loop it to /dev/video99
+wget -qO "$video" "$video_url"
+"$ffmpeg" -hide_banner -loglevel quiet -hwaccel auto \
+    -re -stream_loop -1 -i "$video" \
+    -vf scale="$width:$height" -r "$fps" \
+    -f v4l2 -an -vcodec rawvideo -pix_fmt yuyv422 /dev/video99 &
+pids="$pids $!"
+sleep 3
+
+git_head="$(git rev-parse HEAD)"
+{
+echo "${width}x${height}@$fps for $timeout seconds"
+test $# -eq 0 || echo "extra arguments: $*"
+echo "HEAD: $git_head"; echo
+
+# system information
+uname -srvmo
+sed -n 's/^model name\s*:\s*//p' /proc/cpuinfo | sort | uniq -c; echo
+
+# python information
+python3 -c '
+import importlib.metadata, sys
+venv = (hasattr(sys, "real_prefix") or
+    (hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix))
+print("python", sys.version)
+print("virtualenv", venv)
+print()
+for module in sys.argv[1:]:
+    try:
+        print(module, importlib.metadata.version(module))
+    except importlib.metadata.PackageNotFoundError:
+        print(module, "not found")
+' $(sed -rn 's/^([A-Z0-9][A-Z0-9._-]*[A-Z0-9]).*/\1/pi' requirements.txt); echo
+
+# run fake.py for specified timeout and gather statistics
+export PYTHONUNBUFFERED=yes
+timeout --foreground --preserve-status -s QUIT "$timeout" \
+    ./fake.py -w /dev/video99 -v /dev/video100 \
+        -W "$width" -H "$height" -F "$fps" --no-ondemand "$@" |
+    stdbuf -oL tr '\r' '\n' |
+    python3 -c '
+import sys, statistics
+fps = []
+for line in sys.stdin:
+    if line.startswith("FPS:"):
+        fps.append(float(line.split(":")[-1].strip()))
+        print(fps[-1], end="\r", file=sys.stderr)
+print("avg %.2f, stdev %.2f" %(statistics.mean(fps), statistics.stdev(fps)))
+'
+} | tee "benchmark.$git_head.txt"


### PR DESCRIPTION
Ugly script that should help with #160. The script is based on v4l2loopback and creates `/dev/video99` and `/dev/video100`. `ffmpeg` (or `avconv`) is used to loop a [video](https://google.github.io/mediapipe/images/selfie_segmentation_web.mp4) at 1920x1080 to `/dev/video99` with 60 FPS. fake.py is run for 3 minutes while the FPS counter is collected to calculate average and stdev in the end. Additional parameters like `--hologram` can be given to the script and will passed to `fake.py`.

Using a real camera for the benchmark seems unreliable. My USB camera for example claims to deliver images at 30 FPS, which it sometimes does but then suddenly falls back to 15 FPS until I re-plug it.

For 04a4960dc8daad11ac1d7be15cfe1a591c1fdca2 my results look like this:
```
1920x1080@60 for 180 seconds
HEAD: 04a4960dc8daad11ac1d7be15cfe1a591c1fdca2

Linux 5.14.2-arch1-2 #1 SMP PREEMPT Thu, 09 Sep 2021 09:42:35 +0000 x86_64 GNU/Linux
     12 Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz

python 3.9.7 (default, Aug 31 2021, 13:28:12) 
[GCC 11.1.0]
virtualenv True

numpy 1.21.2
opencv-python 4.5.3.56
pyfakewebcam 0.1.0
mediapipe 0.8.7.3
inotify_simple 1.3.5
cmapy 0.6.6
ConfigArgParse 1.5.2

avg 11.43, stdev 0.67
```

For 2f7d6988a3275b8aa4cbc73bed8151666c5aedef:
```
1920x1080@60 for 180 seconds
HEAD: 2f7d6988a3275b8aa4cbc73bed8151666c5aedef

Linux 5.14.2-arch1-2 #1 SMP PREEMPT Thu, 09 Sep 2021 09:42:35 +0000 x86_64 GNU/Linux
     12 Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz

python 3.9.7 (default, Aug 31 2021, 13:28:12) 
[GCC 11.1.0]
virtualenv True

numpy 1.21.2
opencv-python 4.5.3.56
pyfakewebcam 0.1.0
mediapipe 0.8.7.3
inotify_simple 1.3.5
cmapy 0.6.6
ConfigArgParse 1.5.2

avg 32.74, stdev 4.36
```