### PR TITLE
Allow write access for temporary file creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
         init: true
         build:
             context: ./
-        read_only: true
         volumes:
             - ${IMAGE_BACKGROUND}:/src/background-custom:ro
             - ${IMAGE_FOREGROUND}:/src/foreground-custom:ro


### PR DESCRIPTION
Running the image requires the ability to create temporary directories
and files under a suitable path. The setting `read_only` prevents any
modifications resulting in an error message of:

  FileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp', '/src']

Remove this option to allow local changes to be made to the image.

To retain this option requires adding a `tmpfs: /tmp` to the compose
configuration and will result in a further message being emitted about
Matplotlib not being able to write to the expected directory.
