### PR TITLE
Zoom added Virtual Background without chroma key to linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ## Background
 Video conferencing software support for background blurring and background
-replacement under Linux is relatively poor. The Linux version of Zoom only
-supports background replacement via chroma key. The Linux version of Microsoft
+replacement under Linux is relatively poor. The Linux version of Microsoft
 Team does not support background blur. Over at Webcamoid, we tried to figure out
 if we can do these reliably using open source software
 ([issues/250](https://github.com/webcamoid/webcamoid/issues/250)).


### PR DESCRIPTION
title and:
![image](https://user-images.githubusercontent.com/72273879/150470025-cc6b15e2-6c86-4519-9eb2-910204557d02.png)
