### PR TITLE
Add an example for user systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,22 @@ details, see syntax at https://goo.gl/R74nmi). If an arg is specified in more
 than one place, then commandline values override config file values which
 override defaults.
 ```
+
+### Per-user systemd service
+Copy the systemd service file from `systemd-user` folder to a location
+suitable for user-defined systemd services (typically
+`$HOME/.config/systemd/user`).
+
+Modify the `WorkingDirectory` directive to point to the location of the
+installation, and `ExecStart` directive to configure how `fake.py` is run.
+
+To start the service and enable it so that it is run after login, run the
+following (as normal user):
+```
+$ systemctl --user start fakecam.service
+$ systemctl --user enable fakecam.service
+```
+
 ## License
 The source code of this repository are released under GPLv3.
 

--- a/systemd-user/fakecam.service
+++ b/systemd-user/fakecam.service
@@ -1,0 +1,26 @@
+# systemd user unit file for Linux-Fake-Background-Webcam
+# place this file into a location suitable for user-defined systemd units
+# (e.g $HOME/.config/systemd/user)
+#
+# To enable and run the fakecam service, run
+# systemctl --user enable fakecam.service
+# systemctl --user start fakecam.service
+
+[Unit]
+Description=Fake camera
+After=network.target
+
+[Service]
+Type=simple
+# specify working directory such as Git project directory
+# %h expands to the $HOME directory of the user running the service
+WorkingDirectory=%h/devel/fangfufu/Linux-Fake-Background-Webcam
+# you can use command line options here, or point the script
+# to your config file
+ExecStart=python3 fake.py -c %h/.config/fakecam/config.ini
+# fake.py exits when pressing Ctrl + \ which corresponds to SIGQUIT
+# so we need to specify this kill signal instead of SIGINT
+KillSignal=SIGQUIT
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Hello,

I was configuring your software on my system and was missing some guide on how-to run it as a systemd service. I figured it out eventually and would like to share the resulting setup. When properly configured, fake.py will be automatically runafter user login by Systemd.

```
systemctl --user status fakecam.service
● fakecam.service - Fake camera
     Loaded: loaded (/home/martbab/.config/systemd/user/fakecam.service; enabled; preset: enabled)
     Active: active (running) since Tue 2022-08-23 13:04:00 CEST; 1h 49min ago
   Main PID: 74667 (python3)
      Tasks: 31 (limit: 18908)
     Memory: 17.2M
        CPU: 3min 932ms
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/fakecam.service
             └─74667 python3 fake.py -c /home/martbab/.config/fakecam/config.ini

Aug 23 13:04:00 neurothrope systemd[894]: Started Fake camera.
Aug 23 13:04:00 neurothrope python3[74667]: INFO: Created TensorFlow Lite XNNPACK delegate for CPU.

```