### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix a single typo!

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ To run with a config file, use the following command:
 lfbw -c ./config-example.ini
 ```
 
-The files that you might want to replace are the followings:
+The files that you might want to replace are the following:
 
   - ``background.jpg`` - the background image
   - ``foreground.jpg`` - the foreground image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,10 @@ cmapy = ">=0.6.6"
 configargparse = ">=1.7.1"
 protobuf = ">=4.25.8"
 
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Congrats on having just a single typo... feel free to drop this PR