### PR TITLE
Switch to use video_nr 10 and remove removed CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Once installed, the module needs to be loaded. This can be done manually for
 the current session by running
 
 ```shell
-sudo modprobe v4l2loopback devices=1 exclusive_caps=1 video_nr=2 card_label="fake-cam"
+sudo modprobe v4l2loopback devices=1 exclusive_caps=1 video_nr=10 card_label="fake-cam"
 ```
 
 which will create a virtual video device `/dev/video2`, however, this will not

--- a/config-example.ini
+++ b/config-example.ini
@@ -1,8 +1,6 @@
 width = 1280
 height = 720
 fps = 30
-; no-background = yes
-background-keep-aspect = no
-no-foreground = yes
-webcam-path = /dev/video3
-threshold = 50
+webcam-path = /dev/video0
+v4l2loopback-path = /dev/video10
+; threshold = 50


### PR DESCRIPTION
It is quite likely for people to already have video2 and/or video3 occupied so better to take much higher default number.  This would lead to default conflicts. Also having a distinctive video10 makes is easier to identify this camera.

And then it might also be more likely to have video0 available for the default video camera, thus better to use that video2 or any other.